### PR TITLE
Overhaul BDT Training 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 PandoraMVAData/
+PandoraMVAs/
 PandoraNetworkData/
 *~
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,15 @@ PandoraMVAData/
 PandoraMVAs/
 PandoraNetworkData/
 *~
+scripts/__pycache__/
 
+// By default ignore weights files
+*xml
+*pkl
+
+// Ignore images
+*.pdf
+
+// Jupyter Notebooks
+docs/
+.ipynb_checkpoints/

--- a/ExampleNotebook.ipynb
+++ b/ExampleNotebook.ipynb
@@ -1,0 +1,528 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Add the relevant scripts from LArMachineLearningData\n",
+    "# Nice the process so it can run with lots of cores on low priority\n",
+    "import os\n",
+    "os.nice(20)\n",
+    "\n",
+    "# Add path for LArMachineLearningData\n",
+    "import sys\n",
+    "pandoraMVADir = os.environ['MY_TEST_AREA'] + 'LArMachineLearningData/'\n",
+    "sys.path.append(pandoraMVADir + 'scripts')\n",
+    "\n",
+    "from PandoraBDT import *\n",
+    "\n",
+    "# Import relevant SKLearn stuff\n",
+    "from sklearn.model_selection import StratifiedShuffleSplit\n",
+    "from sklearn.model_selection import GridSearchCV\n",
+    "from sklearn.model_selection import validation_curve\n",
+    "from sklearn.model_selection import learning_curve\n",
+    "from sklearn import metrics\n",
+    "\n",
+    "# Set global params\n",
+    "testTrainFraction = 0.5\n",
+    "nCores = -1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set some analysis specific things\n",
+    "trainingFile = pandoraMVADir + 'SVM_training_data_pfocharacterisation_example.txt'\n",
+    "\n",
+    "BDTName = \"PFOCharBDT\"\n",
+    "\n",
+    "featureNames = ['Length', \n",
+    "                'Straight Line Diff Mean',\n",
+    "                'Max Fit Gap Length', \n",
+    "                'Sliding Linear Fit RMS',\n",
+    "                'Vertex Distance', \n",
+    "                'PCA Secondary-Primary EigenValue Ratio',\n",
+    "                'PCA Tertiary-Primary EigenValue Ratio',\n",
+    "                'Opening Angle Diff', \n",
+    "               ]\n",
+    "\n",
+    "\n",
+    "# Set background and signal label names\n",
+    "params = {\n",
+    "    'labelNames': ['True Shower','True Track'],\n",
+    "    'signalDefs': [0, 1],\n",
+    "    'signalCols': ['r', 'b'],\n",
+    "    'nBins': 100,\n",
+    "    'PlotStep': 1.0,\n",
+    "    'OptimalBinCut': 50,\n",
+    "    'OptimalScoreCut': 0.5,\n",
+    "    'nTrees': 100,\n",
+    "    'TreeDepth': 3,\n",
+    "    'logY': False\n",
+    "}\n",
+    "\n",
+    "# Create the base BDT to vary the params from and compare to\n",
+    "baseBDT = AdaBoostClassifier(DecisionTreeClassifier(max_depth=params['TreeDepth']),algorithm='SAMME', \n",
+    "                         random_state=42, n_estimators=params['nTrees'])\n",
+    "\n",
+    "# Split the data into many subsets to grid search over (Set seed for reproducibility)\n",
+    "cv = StratifiedShuffleSplit(n_splits=5, test_size=0.2, random_state=42)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the data\n",
+    "data, nFeatures, nExamples = LoadData(trainingFile, ',')\n",
+    "featuresOrg, labelsOrg = SplitTrainingSet(data, nFeatures)\n",
+    "features, labels = Randomize(featuresOrg, labelsOrg, True)\n",
+    "\n",
+    "# Split into train and test samples\n",
+    "xTrain, yTrain, xTest, yTest = Sample(features, labels, testTrainFraction)\n",
+    "\n",
+    "# Split into signal and background based on the true labels\n",
+    "signalFeatures = features[labels==1]\n",
+    "backgroundFeatures = features[labels==0]\n",
+    "\n",
+    "# Check the features array is the same size as the feature names array\n",
+    "print (len(featureNames))\n",
+    "print (np.shape(features))\n",
+    "print('Total: '+str(len(features))+', signal: '+\n",
+    "      str(len(signalFeatures))+' and background: '+\n",
+    "      str(len(backgroundFeatures)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Construct the Pandas dataframe\n",
+    "# First crete a dictionary\n",
+    "allDict = {featureNames[i]: features[:, i] for i in range(nFeatures)}\n",
+    "allDict.update({'Labels': labels})\n",
+    "\n",
+    "# Create the Pandas dataframe, create seperate df for signal/background\n",
+    "df = pd.DataFrame(data=allDict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make plots drawing the variables for signal/background\n",
+    "DrawVariablesDF(df, params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make correlation matricies\n",
+    "dfSig = df[df['Labels']==params['signalDefs'][0]].drop('Labels', axis=1)\n",
+    "dfBck = df[df['Labels']==params['signalDefs'][1]].drop('Labels', axis=1)\n",
+    "\n",
+    "CorrelationDF(dfSig, params['labelNames'][0] + ' Correlation Matrix')\n",
+    "CorrelationDF(dfBck, params['labelNames'][1] + ' Correlation Matrix')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If we want to make a plot comparing two variables;\n",
+    "xMetric = 'Vertex Distance'\n",
+    "yMetric = 'PCA Secondary-Primary EigenValue Ratio'\n",
+    "\n",
+    "sns.jointplot(data=df, x=xMetric, y=yMetric, hue='Labels',\n",
+    "              xlim=(np.quantile(df[xMetric], 0.02), np.quantile(df[xMetric], 0.98)), \n",
+    "              ylim=(np.quantile(df[yMetric], 0.02), np.quantile(df[yMetric], 0.98)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For plotting all combos, not very useful when we have too many variables\n",
+    "sns.pairplot(df, hue='Labels')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define size of grid search\n",
+    "depthRange = 3\n",
+    "treeRange = 3\n",
+    "\n",
+    "# Set up ranges for grid search\n",
+    "depthArray = np.linspace(1, depthRange, depthRange, dtype=int)\n",
+    "treeArray = np.logspace(0, treeRange-1, treeRange, dtype=int)\n",
+    "#treeArray = np.linspace(100, 100*treeRange, treeRange, dtype=int)\n",
+    "\n",
+    "# Print arrays for debugging\n",
+    "print (\"Depth Array:\", depthArray)\n",
+    "print (\"Tree Array: \", treeArray)\n",
+    "\n",
+    "# Construct a dictionary to loop over\n",
+    "paramGrid = dict(base_estimator__max_depth=depthArray, n_estimators=treeArray)\n",
+    "\n",
+    "# Perform the grid search\n",
+    "grid = GridSearchCV(baseBDT, param_grid=paramGrid, cv=cv, n_jobs=nCores, \n",
+    "                    verbose=9, refit=True, return_train_score=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the grid search\n",
+    "grid.fit(xTrain, yTrain)\n",
+    "\n",
+    "print(\"The best parameters are %s with a score of %0.2f\"% \n",
+    "      (grid.best_params_, grid.best_score_))\n",
+    "\n",
+    "# Put the output of the grid in a conveneant df\n",
+    "gridResults = pd.DataFrame(grid.cv_results_)\n",
+    "gridResults.rename(columns={\"param_base_estimator__max_depth\": \"MaxDepth\"}, inplace=True)\n",
+    "gridResults.rename(columns={\"param_n_estimators\": \"NTrees\"}, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "testScores = gridResults.pivot(\"MaxDepth\", \"NTrees\", \"mean_test_score\")\n",
+    "testStd = gridResults.pivot(\"MaxDepth\", \"NTrees\", \"std_test_score\")\n",
+    "trainScores = gridResults.pivot(\"MaxDepth\", \"NTrees\", \"mean_train_score\")\n",
+    "\n",
+    "trainTestDiff = trainScores - testScores\n",
+    "\n",
+    "plt.figure(figsize=(4, 4), constrained_layout=True)\n",
+    "sns.heatmap(testScores, cmap='bwr', linewidths=0, annot=True)\n",
+    "plt.title('Validation accuracy: Test')\n",
+    "plt.gca().invert_yaxis()\n",
+    "plt.savefig('TestScores.pdf')\n",
+    "plt.show()\n",
+    "\n",
+    "plt.figure(figsize=(4, 4), constrained_layout=True)\n",
+    "sns.heatmap(testStd, cmap='bwr', linewidths=0, annot=True)\n",
+    "plt.title('Validation accuracy: Std Test Score')\n",
+    "plt.gca().invert_yaxis()\n",
+    "plt.savefig('TrainStds.pdf')\n",
+    "plt.show()\n",
+    "\n",
+    "plt.figure(figsize=(4, 4), constrained_layout=True)\n",
+    "sns.heatmap(trainScores, cmap='bwr', linewidths=0, annot=True)\n",
+    "plt.title('Validation accuracy: Train')\n",
+    "plt.gca().invert_yaxis()\n",
+    "plt.savefig('TrainScores.pdf')\n",
+    "plt.show()\n",
+    "\n",
+    "plt.figure(figsize=(4, 4), constrained_layout=True)\n",
+    "sns.heatmap(trainTestDiff, cmap='bwr', linewidths=0, annot=True)\n",
+    "plt.title('Validation accuracy: Train Test Diff')\n",
+    "plt.gca().invert_yaxis()\n",
+    "plt.savefig('TrainTestDiff.pdf')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reference BDT with controlled hyperparams\n",
+    "baseBDT.fit(xTrain,yTrain)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot ROC curves\n",
+    "fig, ax = plt.subplots()\n",
+    "metrics.plot_roc_curve(grid, xTest, yTest, ax=ax)\n",
+    "metrics.plot_roc_curve(baseBDT, xTest, yTest, ax=ax)\n",
+    "\n",
+    "plt.title(\"ROC Curves\")\n",
+    "ax.invert_xaxis()\n",
+    "ax.legend()\n",
+    "ax.grid()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot Confusion Matricies\n",
+    "fig, ax = plt.subplots()\n",
+    "metrics.plot_confusion_matrix(grid, xTest, yTest, display_labels=params['labelNames'],\n",
+    "                             ax=ax, normalize='true')\n",
+    "ax.invert_xaxis()\n",
+    "#ax.invert_zaxis()\n",
+    "plt.title(\"Confusion matrix (True Normalised)\")\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print more detailed performance info\n",
+    "bdtPredicted = baseBDT.predict(xTest)\n",
+    "gridPredicted = grid.predict(xTest)\n",
+    "\n",
+    "print (\"Background (0): \", params['labelNames'][0])\n",
+    "print (\"Signal (1): \", params['labelNames'][1])\n",
+    "print (\"BDT:\\n\", metrics.classification_report(yTest, bdtPredicted))\n",
+    "print (\"Grid:\\n\", metrics.classification_report(yTest, gridPredicted))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Search performance over training sample size\n",
+    "train_sizes_array = np.linspace(0.0,1, 20)\n",
+    "\n",
+    "train_sizes, train_scores, test_scores = learning_curve(baseBDT, features,\n",
+    "    labels, train_sizes=train_sizes_array[1:], n_jobs=nCores, verbose=9, cv=cv)\n",
+    "\n",
+    "mean_train_scores = np.mean(train_scores, axis=1)\n",
+    "mean_test_scores = np.mean(test_scores, axis=1)\n",
+    "\n",
+    "std_train_scores = np.std(train_scores, axis=1)\n",
+    "std_test_scores = np.std(test_scores, axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot training progression\n",
+    "fig, ax = plt.subplots()\n",
+    "plt.title(\"Training Progression\")\n",
+    "plt.xlabel(\"Number of Training Examples\")\n",
+    "plt.ylabel(\"Score\")\n",
+    "\n",
+    "plt.plot(train_sizes, mean_train_scores, label='Train Score', color='b')\n",
+    "plt.fill_between(train_sizes, mean_train_scores - std_train_scores,\n",
+    "                         mean_train_scores + std_train_scores, alpha=0.1,\n",
+    "                         color=\"b\")\n",
+    "\n",
+    "plt.plot(train_sizes, mean_test_scores, label='Test Score', color='r')\n",
+    "plt.fill_between(train_sizes, mean_test_scores - std_test_scores,\n",
+    "                         mean_test_scores + std_test_scores, alpha=0.1,\n",
+    "                         color=\"r\")\n",
+    "#plt.plot(train_sizes, std_test_scores, label='Test Score Std.', color='k')\n",
+    "\n",
+    "plt.grid()\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Search over a metric\n",
+    "cppalplhaArray = np.linspace(0,0.001,11)\n",
+    "\n",
+    "train_scores, test_scores = validation_curve(\n",
+    "    baseBDT, features, labels, param_name='base_estimator__ccp_alpha',\n",
+    "    param_range=cppalplhaArray, n_jobs=nCores, verbose=9, cv=cv)\n",
+    "\n",
+    "mean_train_scores = np.mean(train_scores, axis=1)\n",
+    "mean_test_scores = np.mean(test_scores, axis=1)\n",
+    "\n",
+    "std_train_scores = np.std(train_scores, axis=1)\n",
+    "std_test_scores = np.std(test_scores, axis=1)\n",
+    "\n",
+    "print (\"Means: \"+str(mean_test_scores)+\" and std. \"\n",
+    "       +str(std_test_scores))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot grid search\n",
+    "plt.plot(cppalplhaArray, mean_train_scores, label='Train Score', color='b')\n",
+    "plt.fill_between(cppalplhaArray, mean_train_scores - std_train_scores,\n",
+    "                         mean_train_scores + std_train_scores, alpha=0.1,\n",
+    "                         color=\"b\")\n",
+    "plt.plot(cppalplhaArray, mean_test_scores, label='Test Score', color='r')\n",
+    "plt.fill_between(cppalplhaArray, mean_test_scores - std_test_scores,\n",
+    "                         mean_test_scores + std_test_scores, alpha=0.1,\n",
+    "                         color=\"r\")\n",
+    "plt.grid()\n",
+    "#plt.xscale('log')\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Search over a metric\n",
+    "learningRateArray = np.linspace(0.1,1.5,15)\n",
+    "\n",
+    "train_scores, test_scores = validation_curve(\n",
+    "    baseBDT, features, labels, param_name='learning_rate',\n",
+    "    param_range=learningRateArray, n_jobs=nCores, verbose=9, cv=cv)\n",
+    "\n",
+    "mean_train_scores = np.mean(train_scores, axis=1)\n",
+    "mean_test_scores = np.mean(test_scores, axis=1)\n",
+    "\n",
+    "std_train_scores = np.std(train_scores, axis=1)\n",
+    "std_test_scores = np.std(test_scores, axis=1)\n",
+    "\n",
+    "print (\"Means: \"+str(mean_test_scores)+\" and std. \"\n",
+    "       +str(std_test_scores))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot grid search\n",
+    "plt.plot(learningRateArray, mean_train_scores, label='Train Score', color='b')\n",
+    "plt.fill_between(learningRateArray, mean_train_scores - std_train_scores,\n",
+    "                         mean_train_scores + std_train_scores, alpha=0.1,\n",
+    "                         color=\"b\")\n",
+    "plt.plot(learningRateArray, mean_test_scores, label='Test Score', color='r')\n",
+    "plt.fill_between(learningRateArray, mean_test_scores - std_test_scores,\n",
+    "                         mean_test_scores + std_test_scores, alpha=0.1,\n",
+    "                         color=\"r\")\n",
+    "plt.grid()\n",
+    "#plt.xscale('log')\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot importance of features\n",
+    "importanceDF = pd.DataFrame({'Features': featureNames, 'Importance Score':baseBDT.feature_importances_})\n",
+    "print (importanceDF.sort_values(by=['Importance Score']))\n",
+    "ax = importanceDF.sort_values(by=['Importance Score'])\\\n",
+    "    .plot(kind='barh', x='Features', y='Importance Score')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Print all tunable params\n",
+    "baseBDT.get_params().keys()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import PandoraBDT\n",
+    "from importlib import reload\n",
+    "\n",
+    "reload (PandoraBDT)\n",
+    "from PandoraBDT import *\n",
+    "\n",
+    "print (np.shape(xTest))\n",
+    "print (np.shape(yTest))\n",
+    "print (np.shape(xTrain))\n",
+    "print (np.shape(yTrain))\n",
+    "\n",
+    "\n",
+    "PlotBdtKSScores(baseBDT, xTest, yTest, xTrain, yTrain, 'Vertex Region', params)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WriteXmlFile(BDTName+\".xml\", baseBDT, BDTName)\n",
+    "SerializeToPkl(BDTName+\".pkl\", baseBDT)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  },
+  "toc-showmarkdowntxt": false
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+### Installation
+In order to install the required packages run `pip install -r requirements.txt` or `conda install --file requirements.txt` depending on your prefered installation method. 
+
 ### Instructions for creating e.g. Pfo Characterisation SVM model 
 Using implementation in [SvmPfoCharacterisationAlgorithm](https://github.com/PandoraPFA/LArContent/blob/master/larpandoracontent/LArTrackShowerId/SvmPfoCharacterisationAlgorithm.cc)
 
@@ -37,3 +40,6 @@ The python script produces also a plot [like](https://github.com/PandoraPFA/Mach
 ```
 
 The SvmName is the one added in the output .xml file, and can be changed in [example.py](https://github.com/PandoraPFA/MachineLearningData/blob/master/scripts/example.py)
+
+### Instructions for trauing a BDT
+The general procedure to create a BDT follows the same structure as the SVM discussed above. The training examples produced by Pandora are compatible between the SVM and BDT models as long as they use the same set of `FeatureTools`. An example notebook, ExampleNotebook.ipynb, has been provided to show the procedure for optimising the hyper-parameters, training and validating the BDT. 

--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ The python script produces also a plot [like](https://github.com/PandoraPFA/Mach
 
 The SvmName is the one added in the output .xml file, and can be changed in [example.py](https://github.com/PandoraPFA/MachineLearningData/blob/master/scripts/example.py)
 
-### Instructions for trauing a BDT
+### Instructions for training a BDT
 The general procedure to create a BDT follows the same structure as the SVM discussed above. The training examples produced by Pandora are compatible between the SVM and BDT models as long as they use the same set of `FeatureTools`. An example notebook, ExampleNotebook.ipynb, has been provided to show the procedure for optimising the hyper-parameters, training and validating the BDT. 

--- a/docs/README.md
+++ b/docs/README.md
@@ -84,4 +84,9 @@ This step is less time and memory consuming, so the input data can be scaled (fo
                 <SvmName>FinalPfoCharacterisation</SvmName>
 		...		
 The SvmName is the one added in the output .xml file, and can be changed in example.py 
-      			 
+
+# Determining Features
+The procedure for determining the features used in the MVA is outlined below, with the current feature sets listed in the experiment specific directories. 
+1. Identify the feature tools that are run in the `<FeatureTools>` XML tag. Note the order in which they are specified here defines the order in which they are run. 
+2. Find the corresponding tools in lar(pandora)content.
+3. Search for where the `featureVector` is appended with new features. Note that each tool can multiple features to the vector, and the order in which the vector is `pushed_back` will determine the order in which the features appear in the training data. 

--- a/docs/SBND/README.md
+++ b/docs/SBND/README.md
@@ -2,10 +2,48 @@
 This document records the feature sets that are used in the current (sbndcode v09_37_01) PandoraSettings XML files. There are currently 3 MVAs run in SBND: Vertexing, PFO Characterisation, and SliceID. Note, however, that there are multiple versions of each of these that are run each with different parameter sets.
 
 # Vertexing
+Two BDTs (Region then Vertex) with very similar variables. Both make comparisons between pairs of candidates and have three types of variables. Event variables describe the event as a whole and are independent of the two candidates, vertex variables describe the candidate and its surrounding hits (therefore you get 2 of each, one for each candidate) and shared variables describe links between the two candidates.
 ### Region
+##### Event Variables
+- Showeryness 
+  - _the proportion of the hits in the event that are currently in "showery" clusters_
+- Area 
+  - _the area taken up by the event in 2D space (drift x wire)_
+  - _both dimensions calculated by the central 90% of hits & averaged across all 3 views_
+- Longitudinality
+  - _the shape of the event, calculated as z / (x + z) where x & z are the drift direction and wire plane lengths respectively_
+  - _0->1 where 0.5 is a perfectly square event_
+- Number of Hits
+- Number of Clusters
+- Number of Vertex Candidates
+##### Vertex Variables
+- Beam Deweighting 
+  - _a measure of how far upstream in the beam direction the candidate lies_
+- Energy Kick
+  - _a measure of the imbalance in transverse energy from the candidate vertex's location_
+- Global Asymmetry
+  - _a measure of how much of the event's energy lies infront or behind the vertex when projected onto an "event axis"_
+- Local Asymmetry
+  - _as global asymmetry but using only clusters in close proximity to the vertex_
+- Shower Asymmetry
+  - _as global asymmetry but using only clusters labelled as "showery"_
+- Energy Deposition Asymmetry
+  - _as global asymmetry but calculate an asymmetry in the energy deposited per unit length along the axis_
+- Energy 
+  - _the sum of the energies of the nearest hit to the candidate in each plane_
+##### Shared Variables
+- Separation
+  - _the distance between the two candidates_
+- Axis Hits
+  - _the number of hits along the axis between the candidates, normalised by the length of the axis (separation)_
 
 ### Vertex
-
+Same as the region BDT but with the addition of a single vertex variable...
+##### Vertex Variables
+- R Phi
+  - _measure of the r/phi distribution of hits in the vicinity of the candidate_
+  
+  
 # PFO Characterisation
 - Length
 - Straight Line Diff Mean

--- a/docs/SBND/README.md
+++ b/docs/SBND/README.md
@@ -1,0 +1,33 @@
+# SBND Feature Tool Sets
+This document records the feature sets that are used in the current (sbndcode v09_37_01) PandoraSettings XML files. There are currently 3 MVAs run in SBND: Vertexing, PFO Characterisation, and SliceID. Note, however, that there are multiple versions of each of these that are run each with different parameter sets.
+
+# Vertexing
+### Region
+
+### Vertex
+
+# PFO Characterisation
+- Length
+- Straight Line Diff Mean
+- Max Fit Gap length
+- Sliding Linear Fit RMS
+- Vertex Distance
+- PCA Secondary-Primary Ratio
+- PCA Tertiary-Primary Ratio
+- Open Angle Difference
+- Fractional Charge Spread
+- Charge End Fraction
+### No Charge Info
+This version of the MVA is run when no collection plane information is available so the calorimetric variables (Fractional Charge Spread and Charge End Fraction) are excluded.
+
+# SliceID
+- Number of Final State PFOs
+- Total Number of Hits
+- Vertex Y (Vertical) Position
+- Weighted Z (Beam) Direction
+- Number of Space-Points in Sphere
+- Eigenvalue Ratio in Sphere
+- Longest Track Y (Vertical) Direction
+- Longest Track Deflection
+- Fraction of Hits in Longest Track
+- Number of Hits in Longest Track

--- a/docs/SBND/README.md
+++ b/docs/SBND/README.md
@@ -5,9 +5,9 @@ This document records the feature sets that are used in the current (sbndcode v0
 Two BDTs (Region then Vertex) with very similar variables. Both make comparisons between pairs of candidates and have three types of variables. Event variables describe the event as a whole and are independent of the two candidates, vertex variables describe the candidate and its surrounding hits (therefore you get 2 of each, one for each candidate) and shared variables describe links between the two candidates.
 ### Region
 ##### Event Variables
-- Showeryness 
+- Showeryness
   - _the proportion of the hits in the event that are currently in "showery" clusters_
-- Area 
+- Area
   - _the area taken up by the event in 2D space (drift x wire)_
   - _both dimensions calculated by the central 90% of hits & averaged across all 3 views_
 - Longitudinality
@@ -17,7 +17,7 @@ Two BDTs (Region then Vertex) with very similar variables. Both make comparisons
 - Number of Clusters
 - Number of Vertex Candidates
 ##### Vertex Variables
-- Beam Deweighting 
+- Beam Deweighting
   - _a measure of how far upstream in the beam direction the candidate lies_
 - Energy Kick
   - _a measure of the imbalance in transverse energy from the candidate vertex's location_
@@ -29,7 +29,7 @@ Two BDTs (Region then Vertex) with very similar variables. Both make comparisons
   - _as global asymmetry but using only clusters labelled as "showery"_
 - Energy Deposition Asymmetry
   - _as global asymmetry but calculate an asymmetry in the energy deposited per unit length along the axis_
-- Energy 
+- Energy
   - _the sum of the energies of the nearest hit to the candidate in each plane_
 ##### Shared Variables
 - Separation
@@ -42,29 +42,29 @@ Same as the region BDT but with the addition of a single vertex variable...
 ##### Vertex Variables
 - R Phi
   - _measure of the r/phi distribution of hits in the vicinity of the candidate_
-  
-  
+
+
 # PFO Characterisation
+Two versions of this MVA are run: When the collection plane is available it is used to calculate the calorimetric (charge) variables and when it is not available these variables are not calculated.
 - Length
-- Straight Line Diff Mean
-- Max Fit Gap length
+- Mean Distance to Linear Fit
+- Max Fit Gap Length
 - Sliding Linear Fit RMS
 - Vertex Distance
 - PCA Secondary-Primary Ratio
 - PCA Tertiary-Primary Ratio
-- Open Angle Difference
-- Fractional Charge Spread
-- Charge End Fraction
-### No Charge Info
-This version of the MVA is run when no collection plane information is available so the calorimetric variables (Fractional Charge Spread and Charge End Fraction) are excluded.
+- Open Angle Difference (Between first and second halves of the PFO)
+### Charge Variables
+- Fractional Charge Spread (sigma / mean)
+- Charge End Fraction (Fraction of Charge in final 10% of PFO)
 
 # SliceID
 - Number of Final State PFOs
 - Total Number of Hits
 - Vertex Y (Vertical) Position
-- Weighted Z (Beam) Direction
-- Number of Space-Points in Sphere
-- Eigenvalue Ratio in Sphere
+- Weighted Z (Beam) Direction of Daughter PFOs
+- Number of Space-Points in Sphere around the vertex
+- Eigenvalue Ratio (Seconday / Primary) in Sphere around the vertex
 - Longest Track Y (Vertical) Direction
 - Longest Track Deflection
 - Fraction of Hits in Longest Track

--- a/download.sh
+++ b/download.sh
@@ -6,6 +6,18 @@ function download() {
 # You want the FILEID
 # Note: For some reason the above function doesn't work for the files, so you need to set the two &id=FILEID instances in the link
 
+if [ -z $MY_TEST_AREA ]
+then
+  echo "MY_TEST_AREA is not set, can't download the files"
+  exit 1
+fi
+
+if [ ! -d $MY_TEST_AREA/LArMachineLearningData/ ]
+then
+  echo "LArMachineLearningData does not exist in MY_TEST_AREA: $MY_TEST_AREA, Not downloading the files"
+  exit 1
+fi
+
 ### PandoraMVAData
 mkdir -p $MY_TEST_AREA/LArMachineLearningData/PandoraMVAData
 cd $MY_TEST_AREA/LArMachineLearningData/PandoraMVAData

--- a/download.sh
+++ b/download.sh
@@ -9,13 +9,13 @@ function download() {
 if [ -z $MY_TEST_AREA ]
 then
   echo "MY_TEST_AREA is not set, can't download the files"
-  exit 1
+  return 1
 fi
 
 if [ ! -d $MY_TEST_AREA/LArMachineLearningData/ ]
 then
   echo "LArMachineLearningData does not exist in MY_TEST_AREA: $MY_TEST_AREA, Not downloading the files"
-  exit 1
+  return 1
 fi
 
 ### PandoraMVAData

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+scipy
+matplotlib
+pandas
+jupyterlab
+seaborn
+sklearn

--- a/scripts/PandoraMVA.py
+++ b/scripts/PandoraMVA.py
@@ -13,16 +13,16 @@ def LoadData(trainingFileName, delimiter=','):
     # Use the first example to get the number of columns
     with open(trainingFileName) as file:
         ncols = len(file.readline().split(delimiter))
-        
+
     # First column is a datestamp, so skip it
-    trainingSet = np.genfromtxt(trainingFileName, delimiter=delimiter, usecols=range(1,ncols), 
-                                dtype=None)
-                                
+    trainingSet = np.genfromtxt(trainingFileName, delimiter=delimiter, usecols=range(1,ncols),
+            dtype=None)
+
     nExamples = trainingSet.size
     nFeatures = ncols - 2 # last column is the response
-    
+
     return np.array(trainingSet), nFeatures, nExamples
-    
+
 #--------------------------------------------------------------------------------------------------
 
 def SplitTrainingSet(trainingSet, nFeatures):
@@ -34,11 +34,11 @@ def SplitTrainingSet(trainingSet, nFeatures):
         features = []
         for i in range(0, nFeatures):
             features.append(float(example[i])) # features in this SVM must be Python float
-            
+
         X.append(features)
 
     return np.array(X).astype(np.float64), np.array(Y).astype(np.int)
-    
+
 #--------------------------------------------------------------------------------------------------
 
 def Randomize(X, Y, setSameSeed=False):
@@ -47,22 +47,22 @@ def Randomize(X, Y, setSameSeed=False):
 
     order = np.random.permutation(Y.size)
     return X[order], Y[order]
-    
+
 #--------------------------------------------------------------------------------------------------
 
 def Sample(X, Y, testFraction=0.1):
     trainSize = int((1.0 - testFraction) * Y.size)
-    
+
     X_train = X[:trainSize]
     Y_train = Y[:trainSize]
     X_test  = X[trainSize:]
     Y_test  = Y[trainSize:]
-    
+
     return X_train, Y_train, X_test, Y_test
-    
+
 #--------------------------------------------------------------------------------------------------
 
-def ValidateModel(model, X_test, Y_test):               
+def ValidateModel(model, X_test, Y_test):
     return model.score(X_test, Y_test)
 
 #--------------------------------------------------------------------------------------------------
@@ -76,7 +76,7 @@ def OverwriteStdout(text):
 def OpenXmlTag(modelFile, tag, indentation):
     modelFile.write((' ' * indentation) + '<' + tag + '>\n')
     return indentation + 4
-    
+
 #--------------------------------------------------------------------------------------------------
 
 def CloseXmlTag(modelFile, tag, indentation):
@@ -96,13 +96,13 @@ def WriteXmlFeatureVector(modelFile, featureVector, tag, indentation):
             firstTime=False
         else:
             modelFile.write(' ' + str(feature))
-            
+
     modelFile.write('</' + tag + '>\n')
-    
+
 #--------------------------------------------------------------------------------------------------
 
 def WriteXmlFeature(modelFile, feature, tag, indentation):
     modelFile.write((' ' * indentation) + '<' + tag + '>')
-    modelFile.write(str(feature))     
+    modelFile.write(str(feature))
     modelFile.write('</' + tag + '>\n')
 


### PR DESCRIPTION
This is a collection of improvements to the training procedure for the Pandora BDTs. The history is very brief due to the repository move but the main features are:
- Update Download script to check environment variables exist to specify the directory
- Add a `requirements.txt` to specify the required packages. I have tested this with both `pip` and `conda` on both my local machine and the Fermilab GPVMs. 
- Remove some hardcoded  naming in `PandoraBDT.py` which was specific to test beam ID from ProtoDUNE
- Make better use of Pandas Dataframes in `PandoraBDT.py`. Note that these function names are appended with `DF` to differentiate them from the existing functions and maintain backwards compatibility
- Add over-training checks by overlaying test and train data and performing a Kolmogorov–Smirnov test
- Move to using a Jupyter notebook to make data exploration and BDT hyper-parameter tuning easier and interactive. This has been configured to run on the provided example PFO characterisation training data but the format is easily extensible to other use cases, e.g. vertexing. 